### PR TITLE
feat: upgrade concurrency for Swift 5.10

### DIFF
--- a/Sources/OG/OGVersion.swift
+++ b/Sources/OG/OGVersion.swift
@@ -1,5 +1,5 @@
 // this file is generated automatically by the build system
 // do not modify this file manually
 public extension OG {
-    static let VERSION = "v1.0.89"
+    static let VERSION = "v1.0.90"
 }

--- a/Sources/OG/OpenGluckClient.swift
+++ b/Sources/OG/OpenGluckClient.swift
@@ -5,18 +5,11 @@ public enum OpenGluckClientError: Error {
     case uploadFailed(message: String)
 }
 
-public class OpenGluckClient {
-    let hostname: String
-    let token: String
-    let target: String
+public actor OpenGluckClientJsonCoders {
+    fileprivate let jsonDecoder: JSONDecoder
+    fileprivate let jsonEncoder: JSONEncoder
 
-    private let jsonDecoder: JSONDecoder
-    private let jsonEncoder: JSONEncoder
-
-    public init(hostname: String, token: String, target: String) {
-        self.hostname = hostname
-        self.token = token
-        self.target = target
+    init() {
         jsonDecoder = JSONDecoder()
         jsonDecoder.dateDecodingStrategy = .custom { decoder -> Date in
             let isoDateFormatter = ISO8601DateFormatter()
@@ -28,11 +21,34 @@ public class OpenGluckClient {
         jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = .iso8601
     }
+}
+
+public final class OpenGluckClient: Sendable {
+    let hostname: String
+    let token: String
+    let target: String
+
+    let coders: OpenGluckClientJsonCoders
+
+    public init(hostname: String, token: String, target: String) {
+        self.hostname = hostname
+        self.token = token
+        self.target = target
+        coders = OpenGluckClientJsonCoders()
+    }
 
     private func clientHeaders() -> [String: String] {
         [
             "Authorization": "Bearer \(token)",
         ]
+    }
+
+    private var jsonDecoder: JSONDecoder {
+        coders.jsonDecoder
+    }
+
+    private var jsonEncoder: JSONEncoder {
+        coders.jsonEncoder
     }
 }
 

--- a/Sources/OG/OpenGluckClient.swift
+++ b/Sources/OG/OpenGluckClient.swift
@@ -6,8 +6,8 @@ public enum OpenGluckClientError: Error {
 }
 
 public actor OpenGluckClientJsonCoders {
-    fileprivate let jsonDecoder: JSONDecoder
-    fileprivate let jsonEncoder: JSONEncoder
+    internal let jsonDecoder: JSONDecoder
+    internal let jsonEncoder: JSONEncoder
 
     init() {
         jsonDecoder = JSONDecoder()
@@ -37,17 +37,17 @@ public final class OpenGluckClient: Sendable {
         coders = OpenGluckClientJsonCoders()
     }
 
-    private func clientHeaders() -> [String: String] {
+    internal func clientHeaders() -> [String: String] {
         [
             "Authorization": "Bearer \(token)",
         ]
     }
 
-    private var jsonDecoder: JSONDecoder {
+    internal var jsonDecoder: JSONDecoder {
         coders.jsonDecoder
     }
 
-    private var jsonEncoder: JSONEncoder {
+    internal var jsonEncoder: JSONEncoder {
         coders.jsonEncoder
     }
 }
@@ -57,7 +57,7 @@ public extension OpenGluckClient {
         return try await getLastDataIfNoneMatch(revision: nil)
     }
 
-    private var origin: String {
+    internal var origin: String {
         if hostname.starts(with: "http://") {
             return hostname
         } else {
@@ -248,7 +248,7 @@ public extension OpenGluckClient {
 
 /* record logs */
 public extension OpenGluckClient {
-    private func toISO8601(_ date: Date = Date()) -> String {
+    internal func toISO8601(_ date: Date = Date()) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         return dateFormatter.string(from: date)
@@ -294,64 +294,6 @@ public extension OpenGluckClient {
                     continuation.resume()
                 }, onError: { err in
                     print("Could not record log, ignoring: \(err)")
-                    continuation.resume()
-                })
-            }
-        #endif
-    }
-}
-
-/* APN token registration */
-extension OpenGluckClient {
-    private var app: String {
-        #if os(iOS)
-            return "iOS"
-        #else
-            return "watchOS"
-        #endif
-    }
-
-    private var apnAppSuffix: String {
-        if let apsEnvironment = MobileProvision.read()?.entitlements.apsEnvironment.rawValue.description, apsEnvironment == "production" {
-            return ".production"
-        }
-        #if DEBUG
-            return ""
-        #else
-            return ".production"
-        #endif
-    }
-
-    public func registerPushKit(deviceToken: String) async throws {
-        #if targetEnvironment(simulator)
-            print("ignore(simulator): register: \(deviceToken)")
-        #else
-            try await withCheckedThrowingContinuation { continuation in
-                let client = HTTPSClient(clientHeaders: clientHeaders())
-                let timestamp = Int(Date().timeIntervalSince1970)
-                let url = URL(string: "\(origin)/opengluck/userdata/apn-\(app)-pushkit\(apnAppSuffix)/zadd?score=\(timestamp)&member=\(deviceToken)")!
-                client.put(url: url, onComplete: { _, _ in
-                    continuation.resume()
-                }, onError: { err in
-                    print("Could not register device token, ignoring: \(err)")
-                    continuation.resume()
-                })
-            }
-        #endif
-    }
-
-    public func register(deviceToken: String) async throws {
-        #if targetEnvironment(simulator)
-            print("ignore(simulator): register: \(deviceToken)")
-        #else
-            try await withCheckedThrowingContinuation { continuation in
-                let client = HTTPSClient(clientHeaders: clientHeaders())
-                let timestamp = Int(Date().timeIntervalSince1970)
-                let url = URL(string: "\(origin)/opengluck/userdata/apn-\(app)\(apnAppSuffix)/zadd?score=\(timestamp)&member=\(deviceToken)")!
-                client.put(url: url, onComplete: { _, _ in
-                    continuation.resume()
-                }, onError: { err in
-                    print("Could not register device token, ignoring: \(err)")
                     continuation.resume()
                 })
             }
@@ -441,147 +383,5 @@ public extension OpenGluckClient {
                 continuation.resume(throwing: err)
             })
         }
-    }
-}
-
-/* instant glucose */
-public extension OpenGluckClient {
-    internal struct OpenGluckUploadInstantGlucoseUploadRequest: Encodable {
-        public let instantGlucoseRecords: [OpenGluckInstantGlucoseRecord]
-
-        // swiftlint:disable nesting
-        enum CodingKeys: String, CodingKey {
-            case instantGlucoseRecords = "instant-glucose-records"
-        }
-
-        // swiftlint:enable nesting
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(instantGlucoseRecords, forKey: .instantGlucoseRecords)
-        }
-    }
-
-    struct OpenGluckUploadInstantGlucoseResult: Codable {
-        public let success: Bool
-        public let status: String
-    }
-
-    func upload(instantGlucoseRecords: [OpenGluckInstantGlucoseRecord]) async throws -> OpenGluckUploadInstantGlucoseResult {
-        try await withCheckedThrowingContinuation { continuation in
-            let client = HTTPSClient(clientHeaders: clientHeaders())
-            let uploadData: Data
-            do {
-                uploadData = try jsonEncoder.encode(OpenGluckUploadInstantGlucoseUploadRequest(instantGlucoseRecords: instantGlucoseRecords))
-            } catch {
-                continuation.resume(throwing: error)
-                return
-            }
-            client.post(url: URL(string: "\(origin)/opengluck/instant-glucose/upload")!, body: uploadData, onComplete: { response, data in
-                guard let data else {
-                    continuation.resume(throwing: OpenGluckClientError.noData)
-                    return
-                }
-                guard response.statusCode == 200 else {
-                    let body = String(data: data, encoding: .utf8) ?? "(no body)"
-                    continuation.resume(throwing: OpenGluckClientError.uploadFailed(message: "Received status code \(response.statusCode), body: \(body)"))
-                    return
-                }
-                let result: OpenGluckUploadInstantGlucoseResult
-                do {
-                    result = try self.jsonDecoder.decode(OpenGluckUploadInstantGlucoseResult.self, from: data)
-                } catch {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                continuation.resume(returning: result)
-            }, onError: { err in
-                print("Could not upload: \(err)")
-                continuation.resume(throwing: err)
-            })
-        }
-    }
-}
-
-/* HbA1c */
-public extension OpenGluckClient {
-    struct OpenGluckHbA1cResult: Codable {
-        public let from_date: Date
-        public let to_date: Date
-        public let hba1c: Double?
-    }
-
-    func getHbA1c(from fromDate: Date, to toDate: Date) async throws -> OpenGluckHbA1cResult {
-        print("Getting HbA1c from \(fromDate) to \(toDate)")
-        return try await withCheckedThrowingContinuation { [self] continuation in
-            let client = HTTPSClient(clientHeaders: clientHeaders())
-            var components = URLComponents()
-            components.queryItems = [
-                URLQueryItem(name: "from", value: self.toISO8601(fromDate)),
-                URLQueryItem(name: "to", value: self.toISO8601(toDate)),
-            ]
-            client.post(url: URL(string: "\(origin)/opengluck/hba1c\(components.string ?? "")")!, onComplete: { response, data in
-                guard let data else {
-                    continuation.resume(throwing: OpenGluckClientError.noData)
-                    return
-                }
-                guard response.statusCode == 200 else {
-                    let body = String(data: data, encoding: .utf8) ?? "(no body)"
-                    continuation.resume(throwing: OpenGluckClientError.uploadFailed(message: "Received status code \(response.statusCode), body: \(body)"))
-                    return
-                }
-                let result: OpenGluckHbA1cResult
-                do {
-                    result = try self.jsonDecoder.decode(OpenGluckHbA1cResult.self, from: data)
-                } catch {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                continuation.resume(returning: result)
-            }, onError: { err in
-                print("Could not get HbA1c: \(err)")
-                continuation.resume(throwing: err)
-            })
-        }
-    }
-
-    func getHbA1cToday() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let midnight = Calendar.current.startOfDay(for: now)
-        return try await getHbA1c(from: midnight, to: now)
-    }
-
-    func getHbA1cLast24Hours() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let fromDate = Calendar.current.date(byAdding: .day, value: -1, to: now)!
-        return try await getHbA1c(from: fromDate, to: now)
-    }
-
-    func getHbA1cYesterday() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let midnight = Calendar.current.startOfDay(for: now)
-        let fromDate = Calendar.current.date(byAdding: .day, value: -1, to: midnight)!
-        return try await getHbA1c(from: fromDate, to: midnight)
-    }
-
-    func getHbA1cLast7Days() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let midnight = Calendar.current.startOfDay(for: now)
-        let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: midnight)!
-        return try await getHbA1c(from: fromDate, to: midnight)
-    }
-
-    func getHbA1cLast30Days() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let midnight = Calendar.current.startOfDay(for: now)
-        let fromDate = Calendar.current.date(byAdding: .day, value: -30, to: midnight)!
-        return try await getHbA1c(from: fromDate, to: midnight)
-    }
-
-    func getHbA1cLast90Days() async throws -> OpenGluckHbA1cResult {
-        let now = Date()
-        let midnight = Calendar.current.startOfDay(for: now)
-        let fromDate = Calendar.current.date(byAdding: .day, value: -90, to: midnight)!
-        return try await getHbA1c(from: fromDate, to: midnight)
     }
 }

--- a/Sources/OG/OpenGluckClient/OpenGluckClientApn.swift
+++ b/Sources/OG/OpenGluckClient/OpenGluckClientApn.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/* APN token registration */
+extension OpenGluckClient {
+    private var app: String {
+        #if os(iOS)
+            return "iOS"
+        #else
+            return "watchOS"
+        #endif
+    }
+
+    private var apnAppSuffix: String {
+        if let apsEnvironment = MobileProvision.read()?.entitlements.apsEnvironment.rawValue.description, apsEnvironment == "production" {
+            return ".production"
+        }
+        #if DEBUG
+            return ""
+        #else
+            return ".production"
+        #endif
+    }
+
+    public func registerPushKit(deviceToken: String) async throws {
+        #if targetEnvironment(simulator)
+            print("ignore(simulator): register: \(deviceToken)")
+        #else
+            try await withCheckedThrowingContinuation { continuation in
+                let client = HTTPSClient(clientHeaders: clientHeaders())
+                let timestamp = Int(Date().timeIntervalSince1970)
+                let url = URL(string: "\(origin)/opengluck/userdata/apn-\(app)-pushkit\(apnAppSuffix)/zadd?score=\(timestamp)&member=\(deviceToken)")!
+                client.put(url: url, onComplete: { _, _ in
+                    continuation.resume()
+                }, onError: { err in
+                    print("Could not register device token, ignoring: \(err)")
+                    continuation.resume()
+                })
+            }
+        #endif
+    }
+
+    public func register(deviceToken: String) async throws {
+        #if targetEnvironment(simulator)
+            print("ignore(simulator): register: \(deviceToken)")
+        #else
+            try await withCheckedThrowingContinuation { continuation in
+                let client = HTTPSClient(clientHeaders: clientHeaders())
+                let timestamp = Int(Date().timeIntervalSince1970)
+                let url = URL(string: "\(origin)/opengluck/userdata/apn-\(app)\(apnAppSuffix)/zadd?score=\(timestamp)&member=\(deviceToken)")!
+                client.put(url: url, onComplete: { _, _ in
+                    continuation.resume()
+                }, onError: { err in
+                    print("Could not register device token, ignoring: \(err)")
+                    continuation.resume()
+                })
+            }
+        #endif
+    }
+}

--- a/Sources/OG/OpenGluckClient/OpenGluckClientHbA1c.swift
+++ b/Sources/OG/OpenGluckClient/OpenGluckClientHbA1c.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/* HbA1c */
+public extension OpenGluckClient {
+    struct OpenGluckHbA1cResult: Codable {
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case fromDate = "from_date"
+            case toDate = "to_date"
+            case hba1c
+        }
+
+        public let fromDate: Date
+        public let toDate: Date
+        public let hba1c: Double?
+    }
+
+    func getHbA1c(from fromDate: Date, to toDate: Date) async throws -> OpenGluckHbA1cResult {
+        print("Getting HbA1c from \(fromDate) to \(toDate)")
+        return try await withCheckedThrowingContinuation { [self] continuation in
+            let client = HTTPSClient(clientHeaders: clientHeaders())
+            var components = URLComponents()
+            components.queryItems = [
+                URLQueryItem(name: "from", value: self.toISO8601(fromDate)),
+                URLQueryItem(name: "to", value: self.toISO8601(toDate)),
+            ]
+            client.post(url: URL(string: "\(origin)/opengluck/hba1c\(components.string ?? "")")!, onComplete: { response, data in
+                guard let data else {
+                    continuation.resume(throwing: OpenGluckClientError.noData)
+                    return
+                }
+                guard response.statusCode == 200 else {
+                    let body = String(data: data, encoding: .utf8) ?? "(no body)"
+                    continuation.resume(throwing: OpenGluckClientError.uploadFailed(message: "Received status code \(response.statusCode), body: \(body)"))
+                    return
+                }
+                let result: OpenGluckHbA1cResult
+                do {
+                    result = try self.jsonDecoder.decode(OpenGluckHbA1cResult.self, from: data)
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result)
+            }, onError: { err in
+                print("Could not get HbA1c: \(err)")
+                continuation.resume(throwing: err)
+            })
+        }
+    }
+
+    func getHbA1cToday() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        return try await getHbA1c(from: midnight, to: now)
+    }
+
+    func getHbA1cLast24Hours() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let fromDate = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        return try await getHbA1c(from: fromDate, to: now)
+    }
+
+    func getHbA1cYesterday() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        let fromDate = Calendar.current.date(byAdding: .day, value: -1, to: midnight)!
+        return try await getHbA1c(from: fromDate, to: midnight)
+    }
+
+    func getHbA1cLast7Days() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: midnight)!
+        return try await getHbA1c(from: fromDate, to: midnight)
+    }
+
+    func getHbA1cLast30Days() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        let fromDate = Calendar.current.date(byAdding: .day, value: -30, to: midnight)!
+        return try await getHbA1c(from: fromDate, to: midnight)
+    }
+
+    func getHbA1cLast90Days() async throws -> OpenGluckHbA1cResult {
+        let now = Date()
+        let midnight = Calendar.current.startOfDay(for: now)
+        let fromDate = Calendar.current.date(byAdding: .day, value: -90, to: midnight)!
+        return try await getHbA1c(from: fromDate, to: midnight)
+    }
+}

--- a/Sources/OG/OpenGluckClient/OpenGluckClientInstantGlucose.swift
+++ b/Sources/OG/OpenGluckClient/OpenGluckClientInstantGlucose.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/* instant glucose */
+public extension OpenGluckClient {
+    internal struct OpenGluckInstantGlucoseUploadRequest: Encodable {
+        public let instantGlucoseRecords: [OpenGluckInstantGlucoseRecord]
+
+        // swiftlint:disable nesting
+        enum CodingKeys: String, CodingKey {
+            case instantGlucoseRecords = "instant-glucose-records"
+        }
+
+        // swiftlint:enable nesting
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(instantGlucoseRecords, forKey: .instantGlucoseRecords)
+        }
+    }
+
+    struct OpenGluckUploadInstantGlucoseResult: Codable {
+        public let success: Bool
+        public let status: String
+    }
+
+    func upload(instantGlucoseRecords: [OpenGluckInstantGlucoseRecord]) async throws -> OpenGluckUploadInstantGlucoseResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let client = HTTPSClient(clientHeaders: clientHeaders())
+            let uploadData: Data
+            do {
+                uploadData = try jsonEncoder.encode(OpenGluckInstantGlucoseUploadRequest(instantGlucoseRecords: instantGlucoseRecords))
+            } catch {
+                continuation.resume(throwing: error)
+                return
+            }
+            client.post(url: URL(string: "\(origin)/opengluck/instant-glucose/upload")!, body: uploadData, onComplete: { response, data in
+                guard let data else {
+                    continuation.resume(throwing: OpenGluckClientError.noData)
+                    return
+                }
+                guard response.statusCode == 200 else {
+                    let body = String(data: data, encoding: .utf8) ?? "(no body)"
+                    continuation.resume(throwing: OpenGluckClientError.uploadFailed(message: "Received status code \(response.statusCode), body: \(body)"))
+                    return
+                }
+                let result: OpenGluckUploadInstantGlucoseResult
+                do {
+                    result = try self.jsonDecoder.decode(OpenGluckUploadInstantGlucoseResult.self, from: data)
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result)
+            }, onError: { err in
+                print("Could not upload: \(err)")
+                continuation.resume(throwing: err)
+            })
+        }
+    }
+}

--- a/Sources/OG/OpenGluckSyncClient.swift
+++ b/Sources/OG/OpenGluckSyncClient.swift
@@ -8,14 +8,18 @@ public protocol OpenGluckSyncClientDelegate: AnyObject {
     func getClient() -> OpenGluckClient?
 }
 
-public class OpenGluckSyncClient {
+public actor OpenGluckSyncClient {
     enum SyncError: Error {
         case noCurrentData
         case noLastData
     }
 
     let semaphore = AsyncSemaphore()
-    public var delegate: OpenGluckSyncClientDelegate?
+    public private(set) var delegate: OpenGluckSyncClientDelegate?
+
+    public func setDelegate(_ delegate: OpenGluckSyncClientDelegate) {
+        self.delegate = delegate
+    }
 
     public private(set) var lastSyncCurrentData: CurrentData?
     public private(set) var lastSyncCurrentDataStart: Date?

--- a/Sources/OGUI/DefaultOGUIThresholdsDelegate.swift
+++ b/Sources/OGUI/DefaultOGUIThresholdsDelegate.swift
@@ -1,4 +1,3 @@
-
 public class DefaultOGUIThresholdsDelegate: OGUIThresholdsDelegate {
     public init() {}
 

--- a/Sources/OGUI/OGUIThresholdsDelegate.swift
+++ b/Sources/OGUI/OGUIThresholdsDelegate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol OGUIThresholdsDelegate {
+public protocol OGUIThresholdsDelegate: AnyObject {
     // when the blood glucose is below normalHigh, it is still considered
     // in the normal range until it reaches low, but in the low range
     var normalLow: Double { get }

--- a/Sources/OGUI/OGUIVersion.swift
+++ b/Sources/OGUI/OGUIVersion.swift
@@ -1,5 +1,5 @@
 // this file is generated automatically by the build system
 // do not modify this file manually
 public extension OGUI {
-    static let VERSION = "v1.0.89"
+    static let VERSION = "v1.0.90"
 }

--- a/Tests/OGTests/OpenGluckSyncClientTests.swift
+++ b/Tests/OGTests/OpenGluckSyncClientTests.swift
@@ -15,17 +15,21 @@ final class OpenGluckSyncClientTests: XCTestCase, OpenGluckSyncClientDelegate {
 
     func testGetCurrentData() async throws {
         let syncClient = OpenGluckSyncClient()
-        syncClient.delegate = self
-        XCTAssertNil(syncClient.durationSinceLastSyncCurrentData)
+        await syncClient.setDelegate(self)
+        let duration = await syncClient.durationSinceLastSyncCurrentData
+        XCTAssertNil(duration)
         _ = try await syncClient.getCurrentData()
-        XCTAssertTrue(syncClient.durationSinceLastSyncCurrentData! < 60)
+        let duration2 = await syncClient.durationSinceLastSyncCurrentData
+        XCTAssertTrue(duration2! < 60)
     }
 
     func testGetLastData() async throws {
         let syncClient = OpenGluckSyncClient()
-        syncClient.delegate = self
-        XCTAssertNil(syncClient.durationSinceLastSyncLastData)
+        await syncClient.setDelegate(self)
+        let duration = await syncClient.durationSinceLastSyncLastData
+        XCTAssertNil(duration)
         _ = try await syncClient.getLastData()
-        XCTAssertTrue(syncClient.durationSinceLastSyncLastData! < 60)
+        let duration2 = await syncClient.durationSinceLastSyncLastData
+        XCTAssertTrue(duration2! < 60)
     }
 }


### PR DESCRIPTION
This PR makes it easier to use `OpenGluckSyncClient` and `OpenGluckClient` from concurrent contexts with Swift 5.10.

This PR also fixes issues with linting that went previously unnoticed in previous PRs (this repo needs GHAs)