### PR TITLE
fix: drop SwiftUI shim from CLI deps on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ import PackageDescription
         ),
         .executableTarget(
             name: "CLI",
-            dependencies: ["SwiftUI", "OG"]
+            dependencies: ["OG"]
         ),
     ]
 #endif


### PR DESCRIPTION
## Summary
- SwiftUI shim is a `.testTarget` on Linux; `CLI` is an `.executableTarget` and can't depend on it (SPM error: *CLI cannot depend on test target dependency SwiftUI*).
- CLI doesn't actually need the shim — removing it from CLI's deps leaves the shim scoped to `OGUITests`.

## Test plan
- [x] `swift build` on Linux (Swift 5.8) — completes cleanly
- [x] `make test` — manifest resolves, all 18 test cases execute (remaining failures are `NSURLErrorDomain -1004`, unrelated network issues)
- [x] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)