### PR TITLE
feat: expose FoodComponent and FoodCarbs fields publicly

### DIFF
--- a/Sources/OGUI/FoodParser.swift
+++ b/Sources/OGUI/FoodParser.swift
@@ -4,14 +4,25 @@ public struct ParsedFood: Equatable {
     public let carbs: Double?
 
     public struct FoodComponent: Equatable {
-        let name: String
-        let carbs: String?
-        let weightInGrams: Double?
+        public let name: String
+        public let carbs: String?
+        public let weightInGrams: Double?
+
+        public init(name: String, carbs: String?, weightInGrams: Double?) {
+            self.name = name
+            self.carbs = carbs
+            self.weightInGrams = weightInGrams
+        }
     }
 
     public struct FoodCarbs: Equatable {
-        let carbs: Double?
-        let percentage: Double?
+        public let carbs: Double?
+        public let percentage: Double?
+
+        public init(carbs: Double?, percentage: Double?) {
+            self.carbs = carbs
+            self.percentage = percentage
+        }
     }
 
     public static func foodComponents(forRecipe recipe: String) -> [String] {

--- a/scripts/release
+++ b/scripts/release
@@ -21,4 +21,4 @@ EOF
 git commit -a -m 'Bump versions in Swift files'
 
 git tag $newtag -m 'Bump version'
-git push && git push origin $newtag
+git push origin HEAD && git push origin $newtag


### PR DESCRIPTION
## Summary
- Promote stored properties on `ParsedFood.FoodComponent` and `ParsedFood.FoodCarbs` to `public` so downstream consumers (e.g. Diably) can read `weightInGrams` etc. without duplicating OG's weight-detection regex.
- Add explicit `public` memberwise initializers (Swift synthesizes an `internal` init by default on public structs).
- Fix `scripts/release` to push the current HEAD explicitly, avoiding ambiguous push targets.

## Test plan
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)